### PR TITLE
Fix/migration

### DIFF
--- a/scripts/procedures/migrations.ts
+++ b/scripts/procedures/migrations.ts
@@ -1,4 +1,54 @@
-import { compat, types as T } from "../deps.ts";
+import { compat, matches, types as T } from "../deps.ts";
 
-export const migration: T.ExpectedExports.migration = compat.migrations
-    .fromMapping({}, "0.3.5" );
+export const migration: T.ExpectedExports.migration =
+  compat.migrations.fromMapping(
+    {
+      "0.2.1": {
+        up: compat.migrations.updateConfig(
+          (config) => {
+            if (
+              matches
+                .shape({
+                  logger: matches.shape({
+                    log_to_file: matches.any,
+                    log_file: matches.any,
+                    log_level_file: matches.any,
+                  }),
+                })
+                .test(config)
+            ) {
+              config.logger.log_to_file = false;
+              config.logger.log_file = "/root/start9/logs.txt";
+              config.logger.log_level_file = 1;
+            }
+            return config;
+          },
+          false,
+          { version: "0.2.1", type: "up" }
+        ),
+        down: compat.migrations.updateConfig(
+          (config) => {
+            if (
+              matches
+                .shape({
+                  logger: matches.shape({
+                    log_to_file: matches.any,
+                    log_file: matches.any,
+                    log_level_file: matches.any,
+                  }),
+                })
+                .test(config)
+            ) {
+              delete config.logger.log_to_file;
+              delete config.logger.log_file;
+              delete config.logger.log_level_file;
+            }
+            return config;
+          },
+          true,
+          { version: "0.2.1", type: "down" }
+        ),
+      },
+    },
+    "0.2.1"
+  );

--- a/scripts/procedures/migrations.ts
+++ b/scripts/procedures/migrations.ts
@@ -6,21 +6,6 @@ export const migration: T.ExpectedExports.migration =
       "0.2.1": {
         up: compat.migrations.updateConfig(
           (config) => {
-            if (
-              matches
-                .shape({
-                  logger: matches.shape({
-                    log_to_file: matches.any,
-                    log_file: matches.any,
-                    log_level_file: matches.any,
-                  }),
-                })
-                .test(config)
-            ) {
-              config.logger.log_to_file = false;
-              config.logger.log_file = "/root/start9/logs.txt";
-              config.logger.log_level_file = 1;
-            }
             return config;
           },
           false,
@@ -28,24 +13,9 @@ export const migration: T.ExpectedExports.migration =
         ),
         down: compat.migrations.updateConfig(
           (config) => {
-            if (
-              matches
-                .shape({
-                  logger: matches.shape({
-                    log_to_file: matches.any,
-                    log_file: matches.any,
-                    log_level_file: matches.any,
-                  }),
-                })
-                .test(config)
-            ) {
-              delete config.logger.log_to_file;
-              delete config.logger.log_file;
-              delete config.logger.log_level_file;
-            }
             return config;
           },
-          true,
+          false,
           { version: "0.2.1", type: "down" }
         ),
       },


### PR DESCRIPTION
Add 0.2.1 migration with `configured: false` to avoid config errors on update/downgrade