### PR TITLE
 Use beta.41 of sdk and minor fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "datum-gateway-startos",
       "dependencies": {
-        "@start9labs/start-sdk": "^0.4.0-beta.36",
+        "@start9labs/start-sdk": "^0.4.0-beta.41",
         "bitcoin-knots": "git+https://github.com/Start9Labs/bitcoin-knots-startos.git#update/040"
       },
       "devDependencies": {
@@ -50,9 +50,9 @@
       }
     },
     "node_modules/@start9labs/start-sdk": {
-      "version": "0.4.0-beta.36",
-      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-0.4.0-beta.36.tgz",
-      "integrity": "sha512-26C1NGJBy/yubp88SriuX2wfVDAM6/1rDx47wdypR2KEqGzhOrMRQC5hJDAMU8BeRAiL6ED8/Ca9CP+5+8BBBw==",
+      "version": "0.4.0-beta.41",
+      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-0.4.0-beta.41.tgz",
+      "integrity": "sha512-nbr6fT8qtAr04lkFBMnUARAAVrTYdjoXA61j/1IzIvA9vkrkras985SE3YSAkgQPYfaAI27wLHQcAn8U0Kk01g==",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@start9labs/start-sdk": "^0.4.0-beta.36",
+    "@start9labs/start-sdk": "^0.4.0-beta.41",
     "bitcoin-knots": "git+https://github.com/Start9Labs/bitcoin-knots-startos.git#update/040"
   },
   "devDependencies": {

--- a/startos/dependencies.ts
+++ b/startos/dependencies.ts
@@ -16,7 +16,7 @@ export const setDependencies = sdk.setupDependencies(async ({ effects }) => {
   return {
     bitcoind: {
       kind: 'running',
-      versionRange: '>#knots:28.1:3-alpha.2',
+      versionRange: '>=29.1:2-beta.0',
       healthChecks: ['primary'],
     },
   }

--- a/startos/install/versions/index.ts
+++ b/startos/install/versions/index.ts
@@ -1,5 +1,6 @@
 import { v_0_4_0_1 } from './v0.4.0.1'
 import { v_0_4_0_2 } from './v0.4.0.2'
+import { v_0_4_0_3 } from './v0.4.0.3'
+export { v_0_4_0_4 as current } from './v0.4.0.4'
 
-export { v_0_4_0_3 as current } from './v0.4.0.3'
-export const other = [v_0_4_0_1, v_0_4_0_2]
+export const other = [v_0_4_0_1, v_0_4_0_2, v_0_4_0_3]

--- a/startos/install/versions/v0.4.0.4.ts
+++ b/startos/install/versions/v0.4.0.4.ts
@@ -1,0 +1,10 @@
+import { VersionInfo } from '@start9labs/start-sdk'
+
+export const v_0_4_0_4 = VersionInfo.of({
+  version: '0.4.0:1-alpha.4',
+  releaseNotes: 'Revamped for StartOS 0.4.0',
+  migrations: {
+    up: async () => {},
+    down: async () => {},
+  }
+})

--- a/startos/interfaces.ts
+++ b/startos/interfaces.ts
@@ -3,7 +3,7 @@ import { stratumPort, uiPort } from './utils'
 
 export const setInterfaces = sdk.setupInterfaces(async ({ effects }) => {
   // UI
-  const uiMulti = sdk.MultiHost.of(effects, 'ui-multi')
+  const uiMulti = sdk.MultiHost.of(effects, 'main')
   const uiMultiOrigin = await uiMulti.bindPort(uiPort, {
     protocol: 'http',
   })
@@ -21,7 +21,7 @@ export const setInterfaces = sdk.setupInterfaces(async ({ effects }) => {
   const uiReceipt = await uiMultiOrigin.export([ui])
 
   // Stratum
-  const stratumMulti = sdk.MultiHost.of(effects, 'stratum-multi')
+  const stratumMulti = sdk.MultiHost.of(effects, 'mining')
   const stratumMultiOrigin = await stratumMulti.bindPort(stratumPort, {
     protocol: null,
     addSsl: null,

--- a/startos/manifest.ts
+++ b/startos/manifest.ts
@@ -46,10 +46,12 @@ export const manifest = setupManifest({
   },
   dependencies: {
     bitcoind: {
-      description: 'Used to generate block templates',
-      optional: false,
-      // TODO update with knots s9pk
-      s9pk: 'https://github.com/Start9Labs/bitcoind-startos/releases/download/v28.1.0.0-alpha/bitcoind.s9pk',
+      description: 'Used to subscribe to new block events.',
+      optional: true,
+      metadata: {
+        title: 'A Bitcoin Full Node',
+        icon: 'https://bitcoin.org/img/icons/opengraph.png',
+      },
     },
   },
 })


### PR DESCRIPTION
Update to beta.41 of sdk
Allow any bitcoin full node
Use 0.3.5.1 interface names for backwards compatibility.
Bump version

