### PR TITLE
add README and CONTRIBUTING, other small touch ups

### DIFF
--- a/.github/workflows/buildService.yml
+++ b/.github/workflows/buildService.yml
@@ -4,34 +4,20 @@ on:
   workflow_dispatch:
   pull_request:
     paths-ignore: ['*.md']
-    branches: ['main', 'master']
+    branches: ['main', 'master', 'next']
   push:
     paths-ignore: ['*.md']
-    branches: ['main', 'master']
+    branches: ['main', 'master', 'next']
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  BuildPackage:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Prepare StartOS SDK
-        uses: Start9Labs/sdk@v1
-
-      - name: Checkout services repository
-        uses: actions/checkout@v4
-
-      - name: Build the service package
-        id: build
-        run: |
-          git submodule update --init --recursive
-          start-sdk init
-          make
-          PACKAGE_ID=$(yq -oy ".id" manifest.*)
-          echo "package_id=$PACKAGE_ID" >> $GITHUB_ENV
-          printf "\n SHA256SUM: $(sha256sum ${PACKAGE_ID}.s9pk) \n"
-        shell: bash
-
-      - name: Upload .s9pk
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ env.package_id }}.s9pk
-          path: ./${{ env.package_id }}.s9pk
+  build:
+    if: github.event.pull_request.draft == false
+    uses: start9labs/shared-workflows/.github/workflows/buildService.yml@master
+    # with:
+    #   FREE_DISK_SPACE: true
+    secrets:
+      DEV_KEY: ${{ secrets.DEV_KEY }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+# Contributing
+
+## Building and Development
+
+See the [StartOS Packaging Guide](https://docs.start9.com/packaging-guide/) for complete environment setup and build instructions.
+
+### Quick Start
+
+```bash
+# Install dependencies
+npm ci
+
+# Build universal package
+make
+```

--- a/README.md
+++ b/README.md
@@ -1,92 +1,241 @@
 <p align="center">
-  <img src="icon.png" alt="Project Logo" width="21%">
+  <img src="icon.png" alt="Datum Gateway Logo" width="21%">
 </p>
 
-# Datum for StartOS
+# Datum Gateway on StartOS
 
-Datum is a simple, minimal project that serves as a template for creating a service that runs on StartOS. This repository creates the `s9pk` package that is installed to run `datum` on [StartOS](https://github.com/Start9Labs/start-os/). Learn more about service packaging in the [Developer Docs](https://start9.com/latest/developer-docs/).
+> **Upstream docs:** <https://ocean.xyz/docs/datum>
+>
+> Everything not listed in this document should behave the same as upstream
+> Datum Gateway v0.4.1. If a feature, setting, or behavior is not mentioned
+> here, the upstream documentation is accurate and fully applicable.
+
+DATUM (Decentralized Alternative Templates for Universal Mining) enables miners to create custom block templates using their own Bitcoin node, either for pooled mining on DATUM-supporting pools (such as OCEAN) or for solo mining. See the [upstream repo](https://github.com/ocean-xyz/datum-gateway) for general Datum Gateway documentation.
+
+---
+
+## Table of Contents
+
+- [Image and Container Runtime](#image-and-container-runtime)
+- [Volume and Data Layout](#volume-and-data-layout)
+- [Installation and First-Run Flow](#installation-and-first-run-flow)
+- [Configuration Management](#configuration-management)
+- [Network Access and Interfaces](#network-access-and-interfaces)
+- [Actions](#actions-startos-ui)
+- [Backups and Restore](#backups-and-restore)
+- [Health Checks](#health-checks)
+- [Dependencies](#dependencies)
+- [Limitations and Differences](#limitations-and-differences)
+- [What Is Unchanged from Upstream](#what-is-unchanged-from-upstream)
+- [Contributing](#contributing)
+- [Quick Reference for AI Consumers](#quick-reference-for-ai-consumers)
+
+---
+
+## Image and Container Runtime
+
+| Property | Value |
+|----------|-------|
+| Image | Custom Dockerfile (multi-stage Debian Bookworm build from upstream C source) |
+| Architectures | x86_64, aarch64 |
+| Entrypoint | `datum_gateway -c /root/data/datum_gateway_config.json` |
+
+The custom Dockerfile compiles `datum_gateway` from source using CMake with dependencies: libmicrohttpd, libjansson, libcurl, libgcrypt, and libsodium.
+
+## Volume and Data Layout
+
+| Volume | Mount Point | Purpose |
+|--------|-------------|---------|
+| `main` | `/root` | All Datum Gateway data (config, logs) |
+
+The Bitcoin node's data volume is also mounted read-only at `/mnt/knots` for cookie-based RPC authentication.
+
+Key files on the `main` volume:
+
+| File | Purpose |
+|------|---------|
+| `data/datum_gateway_config.json` | All Datum Gateway configuration (managed by StartOS actions) |
+
+## Installation and First-Run Flow
+
+1. A default `datum_gateway_config.json` is written with sensible defaults, pre-configured to mine on OCEAN pool (`datum-beta1.mine.ocean.xyz`)
+2. Two **critical tasks** are created prompting the user to:
+   - **Set an admin password** — required to access the Datum Gateway dashboard
+   - **Set a pool address** — the Bitcoin address for mining rewards
+3. Bitcoin RPC is pre-configured to connect to the local `bitcoind` service via cookie authentication (`/mnt/knots/.cookie`)
+4. A dependency task is created on `bitcoind` to set `blocknotify` to `curl -s -m5 http://datum.startos:7152/NOTIFY`, ensuring Datum receives new block notifications
+
+## Configuration Management
+
+Datum Gateway is configured through **StartOS actions** that write to `datum_gateway_config.json` on the `main` volume.
+
+### Set Config Action
+
+The **Set Config** action provides a comprehensive form covering all configuration sections:
+
+| Section | Settings |
+|---------|----------|
+| **Bitcoin RPC** | RPC URL (immutable, `http://bitcoind.startos:8332`), work update interval (5–120 seconds) |
+| **Stratum Server** | Listen port (immutable, 23334), max clients per thread, max threads, max clients, PROXY trust level, vardiff parameters (min difficulty, target shares/min, update speed, delta), stale share timeout, miner fingerprinting, username modifiers for share distribution |
+| **Mining** | Bitcoin payout address, primary/secondary coinbase tags, coinbase unique ID |
+| **API** | Dashboard listen port (immutable, 7152), allow insecure authentication (for Safari) |
+| **Logger** | Console log level (0–5), file logging toggle, log file path, file log level |
+| **Datum Pool** | Pool host, pool port, pool public key, pass workers/full users to pool, always pay self, reward sharing strategy (require/prefer/never) |
+
+Settings **not** managed by StartOS (hardcoded or derived):
+
+| Setting | Value | Reason |
+|---------|-------|--------|
+| `rpccookiefile` | `/mnt/knots/.cookie` | Bitcoin cookie auth via mounted volume |
+| `rpcurl` | `http://bitcoind.startos:8332` | Internal service networking |
+| `listen_addr` (stratum) | `""` (all interfaces) | Required for container networking |
+| `listen_addr` (api) | `""` (all interfaces) | Required for container networking |
+| `notify_fallback` | `true` | Ensures block updates if blocknotify fails |
+
+### Reward Sharing Strategy
+
+The **reward sharing** selector in the Datum Pool section controls pooled vs solo mining:
+
+| Option | Behavior |
+|--------|----------|
+| **Require** (default) | Pool mining required; `pooled_mining_only` = true. If pool host is empty, defaults to OCEAN. If pool goes down, Datum stops issuing work — miners should have backup pools configured |
+| **Prefer** | Pool mining preferred; `pooled_mining_only` = false. Falls back to solo mining if pool is unavailable |
+| **Never** | Solo mining only; clears `pool_host` and sets `pooled_mining_only` = false. All block rewards go to the configured pool address |
+
+### Username Modifiers
+
+The stratum server supports **username modifiers** for distributing mining shares across multiple Bitcoin addresses. Each modifier maps a name to a set of addresses with split percentages (0–1).
+
+## Network Access and Interfaces
+
+| Interface | Port | Protocol | Purpose |
+|-----------|------|----------|---------|
+| Web UI | 7152 | HTTP | Datum Gateway dashboard (admin password required) |
+| Stratum Server | 23334 | TCP (stratum+tcp) | Mining protocol — point ASICs here |
+
+### Connecting Miners
+
+Configure mining hardware with:
+- **URL**: `stratum+tcp://<your-startos-address>:23334`
+- **Username**: Bitcoin payout address, optionally with worker name (e.g., `bc1q...abc.worker1`)
+- **Password**: Ignored — use `x` or leave blank
+
+### Payout Address Behavior (Pooled Mining)
+
+By default, **Pool Pass Full Users** is enabled. This means rewards from OCEAN (or any DATUM-supporting pool) go to the Bitcoin addresses configured in your **miners**, not the address in Datum Gateway's config. The config address acts as a fail-safe for solo mining rewards if the pool goes down.
+
+If you prefer to use a single payout address for all miners, disable **Pool Pass Full Users** in the Set Config action. Then the Bitcoin address in Datum Gateway's config will be used for pool payouts, and you can use just worker names (without addresses) in your miners.
+
+### Failover Behavior
+
+With the default **Require** reward sharing strategy, if the pool connection fails, Datum Gateway stops issuing work. Miners should be configured with backup pool(s) to fail over to.
+
+With the **Prefer** strategy, Datum Gateway falls back to solo mining if the pool is unavailable, continuing to issue work using your own block templates.
+
+## Actions (StartOS UI)
+
+### Config
+
+| Action | Purpose | Inputs | Availability |
+|--------|---------|--------|-------------|
+| **Set Config** | Configure all Datum Gateway settings | Full config form (6 sections) | Any |
+| **Config Pool Address** | Set the Bitcoin address for mining rewards | Bitcoin address | Any |
+| **Create/Reset Password** | Generate admin password for the dashboard | None | Any |
+
+The **Create/Reset Password** action dynamically shows "Create Password" when no password is set, and "Reset Password" otherwise. It generates a 22-character random password and saves it to the config.
+
+## Backups and Restore
+
+**Backed up:** The entire `main` volume, including `datum_gateway_config.json` (all configuration and credentials).
+
+**Restore behavior:** Restoring overwrites current configuration with the backup copy.
+
+## Health Checks
+
+| Check | Method | Messages |
+|-------|--------|----------|
+| **Web Interface** | `checkPortListening` on port 7152 | Ready: "The Datum Gateway dashboard is ready" |
+| **Stratum Interface** | `checkPortListening` on port 23334 (1s timeout) | Ready: "Stratum server is available" |
+
+The Stratum health check requires the primary daemon to be ready first.
 
 ## Dependencies
-- [docker](https://docs.docker.com/get-docker)
-- [docker-buildx](https://docs.docker.com/buildx/working-with-buildx/)
-- [make](https://www.gnu.org/software/make/)
-- [start-cli](https://github.com/Start9Labs/start-os/)
 
-## Build enviroment
-Prepare your build environment. In this example we are using Ubuntu 20.04.
+| Dependency | Required | Version | Purpose |
+|------------|----------|---------|---------|
+| **Bitcoin Node** (`bitcoind`) | Optional | >= 29.1:2-beta.0 | Block template generation via `getblocktemplate`; new block notifications via `blocknotify` |
 
-1. Install docker
-    ```
-    curl -fsSL https://get.docker.com -o- | bash
-    sudo usermod -aG docker "$USER"
-    exec sudo su -l $USER
-    ```
-1. Set buildx as the default builder
-    ```
-    docker buildx install
-    docker buildx create --use
-    ```
-1. Enable cross-arch emulated builds in docker
-    ```
-    docker run --privileged --rm linuxkit/binfmt:v0.8
-    ```
-1. Install essential build packages:
-    ```
-    sudo apt-get install -y build-essential openssl libssl-dev libc6-dev clang libclang-dev ca-certificates
-    ```
-1. Install Rust
-    ```
-    curl https://sh.rustup.rs -sSf | sh
-    # Choose nr 1 (default install)
-    source $HOME/.cargo/env
-    ```
-1. Build and install start-cli
-    ```
-    cd ~/ && git clone --recursive https://github.com/Start9Labs/start-os.git
-    make cli
-    start-cli init
-    ```
+When the Bitcoin dependency is configured, Datum Gateway automatically creates a task on `bitcoind` to set `blocknotify = curl -s -m5 http://datum.startos:7152/NOTIFY`. This task is re-evaluated on every init to ensure the setting persists.
 
-## Cloning
-Clone the project locally. 
+Bitcoin Knots is recommended over Bitcoin Core for its superior template controls and mempool filtering.
 
+## Limitations and Differences
+
+1. **Custom Docker image** — compiled from source with CMake; includes runtime dependencies (libmicrohttpd, libjansson, libsodium) not in upstream binary releases
+2. **RPC cookie auth enforced** — always uses the mounted Bitcoin node's `.cookie` file; no manual RPC credentials
+3. **Immutable ports** — stratum (23334) and dashboard (7152) ports cannot be changed through the config action
+4. **Admin password required** — a critical task forces password creation before the dashboard is accessible
+5. **Pool address required** — a critical task forces pool address configuration before mining can begin
+6. **blocknotify auto-configured** — the `bitcoind` blocknotify setting is automatically managed; manual changes will be overwritten
+7. **Config file not editable via dashboard** — `modify_conf` is hardcoded to `false`; all configuration changes must go through StartOS actions
+
+## What Is Unchanged from Upstream
+
+- Stratum mining protocol (stratum+tcp)
+- Block template generation via `getblocktemplate`
+- Variable difficulty (vardiff) algorithm
+- Coinbase tag and unique ID handling
+- DATUM pool protocol (encrypted connection to pool server)
+- Username-based payout addressing (Pool Pass Full Users / Pool Pass Workers)
+- Worker identification and fingerprinting
+- Share validation and stale share handling
+- Failover behavior (pooled → stop or pooled → solo, depending on config)
+- Dashboard UI and monitoring features
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for build instructions and development workflow.
+
+---
+
+## Quick Reference for AI Consumers
+
+```yaml
+package_id: datum
+upstream_version: "0.4.1"
+image: custom Dockerfile (built from Datum Gateway C source)
+architectures: [x86_64, aarch64]
+volumes:
+  main: /root
+dependency_mounts:
+  bitcoind_main: /mnt/knots (read-only)
+ports:
+  ui: 7152
+  stratum: 23334
+dependencies:
+  - bitcoind (optional, >= 29.1:2-beta.0)
+startos_managed_files:
+  - data/datum_gateway_config.json
+actions:
+  - set-config
+  - config-pool-address
+  - reset-password
+health_checks:
+  - checkPortListening:7152: web_interface
+  - checkPortListening:23334: stratum_interface
+backup_volumes:
+  - main (full volume)
+auto_configured_dependency_settings:
+  bitcoind:
+    blocknotify: "curl -s -m5 http://datum.startos:7152/NOTIFY"
+init_tasks:
+  - reset-password (critical, if no admin password set)
+  - config-pool-address (critical, if no pool address set)
+config_sections:
+  - bitcoind (RPC settings)
+  - stratum (server tuning, vardiff, username modifiers)
+  - mining (payout address, coinbase tags)
+  - api (dashboard settings)
+  - logger (log levels, file logging)
+  - datum (pool connection, reward sharing strategy)
 ```
-git clone https://github.com/ocean-xyz/datum-gateway-startos
-cd datum-gateway-startos
-```
-
-## Building
-To build the package, run one of the following commands:
-
-```
-# for multi platform
-make
-```
-```
-# for amd64
-make x86
-```
-```
-# for arm64
-make arm
-```
-
-## Installing on StartOS
-
-### CLI
-
-> Change *adjective-noun.local* to your Start9 server address
-
-```
-start-cli auth login
-# Enter your Start9 server master password
-start-cli --host https://adjective-noun.local package install datum.s9pk
-```
-
-### UI
-
-Select the Sideload Utility from the StartOS UI header and drag-n-drop the s9pk file to upload and install.
-
-### Verify
-
-Go to your StartOS Services page and select this service to view it's dashboard.

--- a/instructions.md
+++ b/instructions.md
@@ -1,1 +1,0 @@
-@TODO delete me

--- a/startos/actions/configPoolAddress.ts
+++ b/startos/actions/configPoolAddress.ts
@@ -61,7 +61,7 @@ export const configPoolAddress = sdk.Action.withInput(
 
     return {
       version: '1',
-      title: i18n('Sucess'),
+      title: i18n('Success'),
       message: i18n('Bitcoin address set.'),
       result: null,
     }

--- a/startos/i18n/dictionaries/default.ts
+++ b/startos/i18n/dictionaries/default.ts
@@ -38,7 +38,6 @@ const dict = {
   'Config pool address': 72,
   'Config the pool address to mine on.': 73,
   'Bitcoin address set.': 74,
-  'Sucess': 75,
 
   // setConfig
   'Set Config': 100,

--- a/startos/i18n/dictionaries/translations.ts
+++ b/startos/i18n/dictionaries/translations.ts
@@ -38,7 +38,6 @@ export default {
     72: 'Configurer l\'adresse pour la pool',
     73: 'Configurer l\'adresse pour la pool sur laquelle miner',
     74: 'Adresse Bitcoin configurée',
-    75: 'Succès',
 
     // setConfig
     100: 'Définir la configuration',
@@ -52,7 +51,7 @@ export default {
     204: 'Mise à jour du travail en secondes',
     205: 'à quelle fréquence bitcoind doit envoyer les mise à jour du modèle de bloc',
     206: 'Réglages du serveur Stratum',
-    207: 'Conguration du serveur stratum de Datum gateway',
+    207: 'Configuration du serveur stratum de Datum gateway',
     208: 'Port d\'écoute',
     209: 'Port d\'écoute pour Stratum',
     210: 'Nombre maximum de clients par Thread',
@@ -84,7 +83,7 @@ export default {
     236: 'Doit être une addresse Bitcoin valide',
     237: 'Pourcentage attribué à l\'adresse',
     238: 'Réglages du minage',
-    239: 'régalges du minage',
+    239: 'réglages du minage',
     240: 'Adresse Bitcoin',
     241: 'Adresse Bitcoin utilisée pour le minage sur DATUM Pool et pour les récompenses de minage en solo.',
     242: 'Tag principal de la coinbase',

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -1,11 +1,5 @@
 import { setupManifest } from '@start9labs/start-sdk'
-import { SDKImageInputSpec } from '@start9labs/start-sdk/base/lib/types/ManifestTypes'
-import { short, long } from 'bitcoin-knots/startos/manifest/i18n'
-
-const BUILD = process.env.BUILD || ''
-
-const architectures =
-  BUILD === 'x86_64' || BUILD === 'aarch64' ? [BUILD] : ['x86_64', 'aarch64']
+import { short, long } from './i18n'
 
 export const manifest = setupManifest({
   id: 'datum',
@@ -28,26 +22,15 @@ export const manifest = setupManifest({
           workdir: '.',
         },
       },
-      arch: architectures,
-    } as SDKImageInputSpec,
-  },
-  hardwareRequirements: {
-    arch: architectures,
-  },
-  alerts: {
-    install: null,
-    update: null,
-    uninstall: null,
-    restore: null,
-    start: null,
-    stop: null,
+      arch: ['x86_64', 'aarch64'],
+    },
   },
   dependencies: {
     bitcoind: {
       description: 'Used to subscribe to new block events.',
       optional: true,
       metadata: {
-        title: 'A Bitcoin Full Node',
+        title: 'Bitcoin',
         icon: 'https://bitcoin.org/img/icons/opengraph.png',
       },
     },


### PR DESCRIPTION
Main purpsose of the PR is to add a comprehensive README that will  serve to explain the architecture of datum on StartOS and the *diff* between Datum on StartOS and Datum on other platforms. This is our new strategy for READMEs for StartOS service packages in order to train LLMs to provide StartOS-sepcific support to end users.

There was one spelling error, some cruft in the Manifest that I cleaned up as well.

The new workflow will make testing s9pk easy